### PR TITLE
ElasticSearch document ID naming convention has been changed to "ID" …

### DIFF
--- a/src/DataObject/PrimitiveDataObjectFactory.php
+++ b/src/DataObject/PrimitiveDataObjectFactory.php
@@ -80,7 +80,7 @@ class PrimitiveDataObjectFactory
                 'index' => [
                     '_index' => $this->index->getName(),
                     '_type' => $this->index->getType(),
-                    '_id' => $record->ID,
+                    '_id' => $record->ID . $record->ClassName,
                 ],
             ];
             $data[] = json_encode($settings)."\n".json_encode($record);


### PR DESCRIPTION
…+ "ClassName"