### PR TITLE
Unique ID implementation applied to index/removeRecord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .sass-cache
-
 /vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Author: [Andrew Mc Cormack](https://github.com/Andrew-Mc-Cormack)
 __For SilverStripe 4.*__
 
 * [Installation](#installation)
+* [Configuration](#configuration)
 * [Setting Your Elastic Search Endpoint](#setting-your-elastic-search-endpoint)
 * [Setting DataObject Indexable Fields and Relations](#setting-dataobject-indexable-fields-and-relations)
 * [Performing Actions on a Search Index](#performing-actions-on-a-search-index)
@@ -37,6 +38,11 @@ Add the following to your composer.json file and run /dev/build?flush=all
     }
 }
 ```
+
+## Configuration
+
+Refer to `_config/searchly.yml` for configuration options.
+
 
 ## Setting Your Elastic Search Endpoint
 

--- a/_config/searchly.yml
+++ b/_config/searchly.yml
@@ -1,0 +1,8 @@
+---
+name: silverstripe-searchly
+---
+
+CyberDuck\Searchly\Index\SearchIndex:
+  id_hash_enabled: true
+  id_hash_algo: 'md5'
+  id_hash_length: 12

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "issues": "https://github.com/cyber-duck/silverstripe-searchly"
     },
     "require": {
-        "guzzlehttp/guzzle": "~6"
+        "php": ">=7.0.0",
+        "guzzlehttp/guzzle": "~6",
+        "silverstripe/framework": "^4"
     },
     "autoload": {
         "classmap": [

--- a/src/DataObject/PrimitiveDataObjectFactory.php
+++ b/src/DataObject/PrimitiveDataObjectFactory.php
@@ -80,7 +80,7 @@ class PrimitiveDataObjectFactory
                 'index' => [
                     '_index' => $this->index->getName(),
                     '_type' => $this->index->getType(),
-                    '_id' => $record->ID . $record->ClassName,
+                    '_id' => $this->index->getRecordID($record),
                 ],
             ];
             $data[] = json_encode($settings)."\n".json_encode($record);


### PR DESCRIPTION
Currently indexRecord and removeRecord still use old ID format (just ID). This updates these methods to use same format as used elsewhere, and adds configurable option (defaulted on, can be disabled via .yml) to populate index _id column with hashed value, with options for hash algorithm and length.