### PR TITLE
Replace method_exists with hasMethod

### DIFF
--- a/src/DataObject/PrimitiveDataObject.php
+++ b/src/DataObject/PrimitiveDataObject.php
@@ -179,8 +179,8 @@ class PrimitiveDataObject
     protected function hasLink(): bool
     {
         return property_exists($this->source, 'Link')
-        || method_exists($this->source, 'Link')
-        || method_exists($this->source, 'getLink');
+            || $this->source->hasMethod('Link')
+            || $this->source->hasMethod('getLink');
     }
 
     /**
@@ -193,15 +193,15 @@ class PrimitiveDataObject
     protected function getLink()
     {
         if ($this->source instanceof SiteTree) {
-            return DataObject::get_by_id(SiteTree::class, $this->source->ID)->AbsoluteLink();
+            return $this->source->AbsoluteLink();
         }
-        if ($this->source instanceof File) {
-            return DataObject::get_by_id(File::class, $this->source->ID)->AbsoluteLink();
+        if ($this->source instanceof File and $this->source->exists()) {
+            return $this->source->AbsoluteLink();
         }
-        if (method_exists('Link', $this->source)) {
+        if ($this->source->hasMethod('Link')) {
             return Director::absoluteURL($this->source->Link());
         }
-        if (method_exists('getLink', $this->source)) {
+        if ($this->source->hasMethod('getLink')) {
             return Director::absoluteURL($this->source->getLink());
         }
 


### PR DESCRIPTION
method_exists doesn't pick up methods added via SS extensions, SS provides it's own ->hasMethod for this purpose, which functions like method_exists + looks up extra methods added via extensions.

Required for indexing objects that have a ->Link method provided via an extension (i.e. Members or other base classes)