### PR TITLE
Porting to Silverstripe 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "~6 || ~7",
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4 || ^5"
     },
     "autoload": {
         "classmap": [

--- a/src/Index/SearchQuery.php
+++ b/src/Index/SearchQuery.php
@@ -18,6 +18,13 @@ namespace CyberDuck\Searchly\Index;
 class SearchQuery
 {
     /**
+     * Settings dictionary.
+     *
+     * @var array
+     */
+    protected $config = [];
+
+    /**
      * Query text string.
      *
      * @var string


### PR DESCRIPTION
Not sure there is something else to do, but with these changes in place I can use searchly without warnings on latest Silverstripe 5.